### PR TITLE
[Fix] quest

### DIFF
--- a/src/main/kotlin/com/meokq/api/file/enums/ImageType.kt
+++ b/src/main/kotlin/com/meokq/api/file/enums/ImageType.kt
@@ -36,5 +36,12 @@ enum class ImageType(
         createPermissions = listOf(UserType.CUSTOMER),
         selectPermissions = listOf(UserType.BOSS, UserType.CUSTOMER),
         deletePermissions = listOf(UserType.CUSTOMER)
-    )
+    ),
+    QUEST_IMAGE(
+        prefix = "QU",
+        description = "퀘스트-이미지",
+        createPermissions = listOf(UserType.BOSS, UserType.ADMIN),
+        selectPermissions = listOf(UserType.BOSS, UserType.ADMIN, UserType.CUSTOMER, UserType.UNKNOWN),
+        deletePermissions = listOf(UserType.BOSS, UserType.ADMIN)
+    ),
 }

--- a/src/main/kotlin/com/meokq/api/quest/controller/QuestController.kt
+++ b/src/main/kotlin/com/meokq/api/quest/controller/QuestController.kt
@@ -4,6 +4,8 @@ import com.meokq.api.core.AuthDataProvider
 import com.meokq.api.core.ResponseEntityCreation
 import com.meokq.api.core.dto.BaseListRespV2
 import com.meokq.api.core.dto.BaseResp
+import com.meokq.api.file.enums.ImageType
+import com.meokq.api.file.request.ImageReq
 import com.meokq.api.quest.annotations.*
 import com.meokq.api.quest.request.QuestCreateReq
 import com.meokq.api.quest.request.QuestCreateReqForAdmin
@@ -16,6 +18,7 @@ import org.springframework.data.domain.PageRequest
 import org.springframework.http.ResponseEntity
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.bind.annotation.*
+import org.springframework.web.multipart.MultipartFile
 
 @Tag(name = "Quest", description = "퀘스트")
 @RestController
@@ -50,11 +53,18 @@ class QuestController(
     @PostMapping(value = ["/boss/quest"])
     @Transactional(rollbackFor = [Exception::class])
     fun saveQuest(
-        @RequestBody @Valid request: QuestCreateReq
-    ): ResponseEntity<BaseResp> {
-        return getRespEntity(service.save(request))
-
+        @RequestBody @Valid request: QuestCreateReq,
+        @RequestParam(name = "file") file: MultipartFile,
+        ): ResponseEntity<BaseResp> {
+        return getRespEntity(service.save(
+            request,
+            ImageReq(
+                file = file,
+                type = ImageType.QUEST_IMAGE),
+                authReq = getAuthReq()
+        ))
     }
+
     @ExplainSaveQuest
     @PostMapping(value = ["/admin/quest" ])
     @Transactional(rollbackFor = [Exception::class])

--- a/src/main/kotlin/com/meokq/api/quest/model/Quest.kt
+++ b/src/main/kotlin/com/meokq/api/quest/model/Quest.kt
@@ -47,4 +47,7 @@ class Quest(
         creatorRole = UserType.ADMIN,
     )
 
+    fun addImageId(imageId: String) {
+        this.imageId = imageId
+    }
 }

--- a/src/main/kotlin/com/meokq/api/quest/model/Quest.kt
+++ b/src/main/kotlin/com/meokq/api/quest/model/Quest.kt
@@ -17,6 +17,8 @@ class Quest(
     @Enumerated(EnumType.STRING)
     var status : QuestStatus = QuestStatus.UNDER_REVIEW,
 
+    var imageId : String? = null,
+
     var marketId : String? = null,
 
     var expireDate : LocalDateTime? = null,
@@ -29,6 +31,7 @@ class Quest(
 
     @Enumerated(EnumType.STRING)
     var creatorRole : UserType = UserType.BOSS,
+
 
     ) : BaseModelV2(){
 

--- a/src/main/kotlin/com/meokq/api/quest/response/QuestDetailResp.kt
+++ b/src/main/kotlin/com/meokq/api/quest/response/QuestDetailResp.kt
@@ -17,8 +17,10 @@ class QuestDetailResp(
     //var missions: List<MissionResp>?,
     //var rewards: List<RewardResp>?,
     val status: QuestStatus?,
-    val expiredData : LocalDateTime
+    val expiredData : LocalDateTime,
+    var imageId: String?,
 ): Serializable{
+
     constructor(model : Quest) : this(
         questId = model.questId,
         marketId = model.marketId,
@@ -27,6 +29,7 @@ class QuestDetailResp(
         //missions = model.missions?.map { MissionResp(it) },
         //rewards =  model.rewards?.map { RewardResp(it) },
         status = model.status,
-        expiredData = model.expireDate?.let { it } ?: LocalDateTime.of(9999, 12, 31, 0, 0, 0)
+        expiredData = model.expireDate?.let { it } ?: LocalDateTime.of(9999, 12, 31, 0, 0, 0),
+        imageId = model.imageId
     )
 }

--- a/src/main/kotlin/com/meokq/api/quest/response/QuestListResp.kt
+++ b/src/main/kotlin/com/meokq/api/quest/response/QuestListResp.kt
@@ -14,6 +14,7 @@ class QuestListResp(
     var status: QuestStatus?,
     var expireDate: String?,
     var creatorRole : String?,
+    var imageId: String?,
 ) {
 
     constructor(model: Quest) : this(
@@ -23,6 +24,7 @@ class QuestListResp(
         rewardTitle = model.rewards?.firstOrNull()?.let { RewardType.getTitle(it) },
         status = model.status,
         expireDate = model.expireDate?.let { DateTimeConverterV2.convertToString(it) },
-        creatorRole = model.creatorRole.toString()
+        creatorRole = model.creatorRole.toString(),
+        imageId = model.imageId
     )
 }

--- a/src/main/kotlin/com/meokq/api/quest/service/QuestService.kt
+++ b/src/main/kotlin/com/meokq/api/quest/service/QuestService.kt
@@ -6,6 +6,8 @@ import com.meokq.api.core.DataValidation.checkNotNullData
 import com.meokq.api.core.JpaService
 import com.meokq.api.core.JpaSpecificationService
 import com.meokq.api.core.repository.BaseRepository
+import com.meokq.api.file.request.ImageReq
+import com.meokq.api.file.service.ImageService
 import com.meokq.api.quest.enums.QuestStatus
 import com.meokq.api.quest.model.Quest
 import com.meokq.api.quest.repository.QuestHistoryRepository
@@ -22,6 +24,7 @@ import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Service
+import org.springframework.web.multipart.MultipartFile
 import java.time.LocalDate
 
 @Service
@@ -29,7 +32,8 @@ class QuestService(
     private val repository : QuestRepository,
     private val missionService: MissionService,
     private val rewardService: RewardService,
-    private val questHistoryRepository: QuestHistoryRepository
+    private val questHistoryRepository: QuestHistoryRepository,
+    private val imageService : ImageService,
 
 ) : JpaService<Quest, String>, JpaSpecificationService<Quest, String> {
     override var jpaRepository: JpaRepository<Quest, String> = repository
@@ -57,10 +61,13 @@ class QuestService(
         return QuestDetailResp(quest)
     }
 
-    fun save(request: QuestCreateReq) : QuestCreateResp {
+    fun save(request: QuestCreateReq, imageRequest : ImageReq, authReq: AuthReq) : QuestCreateResp {
         // save quest
+        val imageId = imageService.save(imageRequest,authReq)
         val modelForSave = Quest(request)
+        modelForSave.addImageId(imageId.imageId!!)
         val model = repository.save(modelForSave)
+
 
         model.questId.also {
             checkNotNullData(it, "해당 퀘스트에는 마켓정보가 등록되어 있지 않습니다.")

--- a/src/main/kotlin/com/meokq/api/quest/service/QuestService.kt
+++ b/src/main/kotlin/com/meokq/api/quest/service/QuestService.kt
@@ -41,7 +41,8 @@ class QuestService(
         val models = findAllBy(specification, pageable)
         val responses = models.map {
             it.questId?.let { id -> it.missions = missionService.findModelsByQuestId(id)
-                                    it.rewards = rewardService.findModelsByQuestId(id)}
+                                    it.rewards = rewardService.findModelsByQuestId(id)
+            }
             QuestListResp(it)
         }
 


### PR DESCRIPTION
#93 

quest엔터티에 imageId 필드 추가  
ㄴ db : quest 테이블에  imageId 컬럼 추가완료
퀘스트 등록시 이미지 추가 하여 quest엔터티에 이미지 아이디 추가해서 저장하도록 구현
퀘스트 조회시 응답 객체에 이미지 아이디 추가 
