### PR TITLE
[fix] 퀘스트 어드민 업로드시 이미지를 같이 업로드 하기

### DIFF
--- a/src/main/kotlin/com/meokq/api/quest/controller/QuestController.kt
+++ b/src/main/kotlin/com/meokq/api/quest/controller/QuestController.kt
@@ -63,13 +63,10 @@ class QuestController(
     @PostMapping(value = ["/admin/quest" ])
     @Transactional(rollbackFor = [Exception::class])
     fun saveQuestAdmin(
-        @RequestBody @Valid request: QuestCreateReqForAdmin,
-        @RequestParam(name = "file") file: MultipartFile,
+        @RequestBody @Valid request: QuestCreateReqForAdmin
     ): ResponseEntity<BaseResp> {
         return getRespEntity(service.adminSave(
-            request = request,
-            imageRequest = ImageReq(file = file, type = ImageType.QUEST_IMAGE),
-            authReq = getAuthReq()
+            request = request
         ))
     }
 

--- a/src/main/kotlin/com/meokq/api/quest/request/QuestCreateReqForAdmin.kt
+++ b/src/main/kotlin/com/meokq/api/quest/request/QuestCreateReqForAdmin.kt
@@ -4,9 +4,10 @@ import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.Pattern
 
 class QuestCreateReqForAdmin(
+    val writer : String,
+    val imageId : String,
     val missions : List<MissionReq>,
     val rewards : List<RewardReq>,
-    val writer : String,
     @Schema(description = "만료 시간")
     @field:Pattern(regexp = "\\d{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])", message = "날짜 형식은 yyyy-MM-dd 이어야 합니다.")
     val expireDate : String

--- a/src/main/kotlin/com/meokq/api/quest/service/QuestService.kt
+++ b/src/main/kotlin/com/meokq/api/quest/service/QuestService.kt
@@ -78,13 +78,11 @@ class QuestService(
         return QuestCreateResp(model)
     }
 
-    fun adminSave(request: QuestCreateReqForAdmin, imageRequest : ImageReq, authReq: AuthReq) : QuestCreateResp {
-        val imageId = imageService.save(imageRequest,authReq)
-
+    fun adminSave(request: QuestCreateReqForAdmin) : QuestCreateResp {
         // save quest
         val modelForSave = Quest(request)
         modelForSave.status = QuestStatus.PUBLISHED
-        modelForSave.addImageId(imageId.imageId!!)
+        modelForSave.addImageId(request.imageId)
 
         val model = repository.save(modelForSave)
 


### PR DESCRIPTION
퀘스트 어드민 업로드시 이미지를 같이 업로드 하기 -> 이미지 api 이용해서 업로드 후 퀘스트 등록때 이미지id 받아서 저장 