### PR TITLE
[fix] 챌린지 삭제 api 기능 변경 (검토중만 삭제 가능 에서 모든 챌린지 삭제 가능)

### DIFF
--- a/src/main/kotlin/com/meokq/api/challenge/annotations/ExplainDeleteChallenge.kt
+++ b/src/main/kotlin/com/meokq/api/challenge/annotations/ExplainDeleteChallenge.kt
@@ -7,8 +7,8 @@ import io.swagger.v3.oas.annotations.media.ExampleObject
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 
 @Operation(
-    summary = "(ICH006) 도전 내역 세부정보 삭제",
-    description = "도전 내역 세부정보를 삭제합니다. (검토중일때만 삭제할 수 있습니다.)",
+    summary = "(ICH006) 도전 내역 삭제",
+    description = "도전 내역을 삭제 합니다.",
     parameters = [
         Parameter(name = "challengeId", description = "도전내역 아이디", required = true, example = "CH10000004"),
     ]

--- a/src/main/kotlin/com/meokq/api/challenge/controller/ChallengeController.kt
+++ b/src/main/kotlin/com/meokq/api/challenge/controller/ChallengeController.kt
@@ -50,14 +50,14 @@ class ChallengeController(
     }
 
     @ExplainDeleteChallenge
-    @DeleteMapping("/customer/{challengeId}")
+    @DeleteMapping("/customer/{challengeId}","/admin/{challengeId}")
     @Transactional(rollbackFor = [Exception::class])
     fun deleteById(@PathVariable challengeId: String) : ResponseEntity<BaseResp> {
         return getRespEntity(service.deleteById(challengeId))
     }
 
     @ExplainUpdateStatusChallenge
-    @PatchMapping("/admin/report","/customer/report")
+    @PatchMapping("/customer/report","/admin/report")
     @Transactional(rollbackFor = [Exception::class])
     fun updateStatus(@RequestParam challengeId: String,
                @RequestParam status: String) : ResponseEntity<BaseResp> {

--- a/src/main/kotlin/com/meokq/api/challenge/enums/ChallengeStatus.kt
+++ b/src/main/kotlin/com/meokq/api/challenge/enums/ChallengeStatus.kt
@@ -3,15 +3,16 @@ package com.meokq.api.challenge.enums
 import com.meokq.api.core.exception.InvalidRequestException
 enum class ChallengeStatus(
     val value : String,
+    // TODO : 240819 챌린지 삭제 정책 변경 (사용자도 삭제 가능하게 변경 됌) 추후 삭제 고려
     val deleteAction : () -> Unit,
 ) {
     APPROVED(
         value = "승인",
-        deleteAction = {throw InvalidRequestException("You can only delete challenges that are under_review.") }
+        deleteAction = {}
     ),
     REJECTED(
         value = "반려",
-        deleteAction = {throw InvalidRequestException("You can only delete challenges that are under_review.") }
+        deleteAction = {}
     ),
     UNDER_REVIEW(
         value = "검토중",
@@ -19,7 +20,7 @@ enum class ChallengeStatus(
     ),
     REPORTED(
         value = "신고",
-        deleteAction = {throw InvalidRequestException("You can only delete challenges that are under_review.") }
+        deleteAction = {}
     );
 
     companion object{


### PR DESCRIPTION
정책 변경에 따른 챌린지 삭제 기능 수정