### PR TITLE
[fix] MissionTarget enum에 null 처리가 안되는 오류 #335

### DIFF
--- a/src/main/kotlin/com/meokq/api/quest/model/Mission.kt
+++ b/src/main/kotlin/com/meokq/api/quest/model/Mission.kt
@@ -3,6 +3,7 @@ package com.meokq.api.quest.model
 import com.meokq.api.core.model.BaseModel
 import com.meokq.api.quest.enums.MissionType
 import com.meokq.api.quest.request.MissionReq
+import jakarta.annotation.Nullable
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
@@ -16,22 +17,24 @@ class Mission(
     var missionId: String? = null,
     var questId: String? = null,
     var quantity: Int? = null,
+    @Nullable
     @Enumerated(EnumType.STRING)
-    var target: MissionTarget? = null,
+    var target: MissionTarget? = MissionTarget.NONE, // 20241112 기본값 설정.
     var content: String? = null,
     @Enumerated(EnumType.STRING)
     var type : MissionType? = null,
+
 ) : BaseModel(){
     constructor(req : MissionReq) : this(
         content = req.content,
-        //target = MissionTarget.valueOf(req.target?:""),
+        //target = MissionTarget.valueOf(req.target?:""), // TODO : 확인필요.
         quantity = req.quantity,
         type = req.type
     )
 
     constructor(req: MissionReq, questId: String) : this(
         content = req.content,
-        //target = MissionTarget.valueOf(req.target?:""),
+        //target = MissionTarget.valueOf(req.target?:""), // TODO : 확인필요.
         quantity = req.quantity,
         type = req.type,
         questId = questId

--- a/src/main/kotlin/com/meokq/api/quest/model/MissionTarget.kt
+++ b/src/main/kotlin/com/meokq/api/quest/model/MissionTarget.kt
@@ -5,6 +5,9 @@ enum class MissionTarget {
     WEEKLY,
     MONTHLY,
 
+    // 유효하지 않거나, 비어있지 않은 데이터
+    NONE,
+
     // TODO delete
     XP,
 }

--- a/src/main/resources/common.yml
+++ b/src/main/resources/common.yml
@@ -1,5 +1,5 @@
 apiProject:
-  version: V.1.2.0-202411110237
+  version: V.1.2.0-202411122242
 
 spring:
   config:


### PR DESCRIPTION
- MissionTarget 항목에 null이 들어가 있으면 ""로 처리되는 오류.
- 우선 NONE 기본값 설정. 추후에 반복 퀘스트 로직 수정시에 한번 더 확인 필요함.