### PR TITLE
[fix] 랜덤 조회시 기준 변경 & DB 데이터 조회로 변경

### DIFF
--- a/src/main/kotlin/com/meokq/api/challenge/model/Challenge.kt
+++ b/src/main/kotlin/com/meokq/api/challenge/model/Challenge.kt
@@ -4,10 +4,7 @@ import com.meokq.api.challenge.enums.ChallengeStatus
 import com.meokq.api.challenge.request.ChallengeSaveReq
 import com.meokq.api.core.model.BaseDateTimeModel
 import com.meokq.api.emoji.response.EmojiResp
-import jakarta.persistence.Entity
-import jakarta.persistence.EnumType
-import jakarta.persistence.Enumerated
-import jakarta.persistence.Id
+import jakarta.persistence.*
 import lombok.EqualsAndHashCode
 import org.apache.commons.lang3.builder.EqualsExclude
 import org.hibernate.annotations.CreationTimestamp
@@ -15,7 +12,8 @@ import org.hibernate.annotations.UpdateTimestamp
 import org.hibernate.annotations.UuidGenerator
 import java.time.LocalDateTime
 
-@Entity(name = "tb_challenge_history")
+@Entity
+@Table(name = "tb_challenge_history")
 data class Challenge(
     @Id
     /*@GenericGenerator(

--- a/src/main/kotlin/com/meokq/api/challenge/repository/ChallengeRepository.kt
+++ b/src/main/kotlin/com/meokq/api/challenge/repository/ChallengeRepository.kt
@@ -5,11 +5,17 @@ import com.meokq.api.challenge.model.Challenge
 import com.meokq.api.core.repository.BaseRepository
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.Query
 
 interface ChallengeRepository : BaseRepository<Challenge, String> {
     fun findAllByStatus(status: ChallengeStatus): List<Challenge>
     fun deleteAllByQuestId(questId:String)
     fun findAllByQuestId(questId: String): List<Challenge>
     fun countByCustomerIdAndStatus(customerId: String, status: ChallengeStatus): Long
-
+    @Query("""
+        SELECT c
+        FROM Challenge AS c
+        ORDER BY CASE WHEN c.likeEmojiCnt = 0 THEN 1 ELSE 0 END ASC, c.updateDate DESC
+    """)
+    fun findAllRandomChallenge(pageable: Pageable): Page<Challenge>
 }

--- a/src/main/kotlin/com/meokq/api/challenge/service/ChallengeService.kt
+++ b/src/main/kotlin/com/meokq/api/challenge/service/ChallengeService.kt
@@ -18,7 +18,6 @@ import com.meokq.api.core.JpaService
 import com.meokq.api.core.JpaSpecificationService
 import com.meokq.api.core.enums.TargetType
 import com.meokq.api.core.exception.AccessDeniedException
-import com.meokq.api.core.exception.InvalidRequestException
 import com.meokq.api.core.exception.NotFoundException
 import com.meokq.api.core.model.TargetMetadata
 import com.meokq.api.core.repository.BaseRepository
@@ -31,7 +30,6 @@ import com.meokq.api.quest.repository.QuestRepository
 import com.meokq.api.quest.response.QuestResp
 import com.meokq.api.quest.service.QuestHistoryService
 import com.meokq.api.quest.service.RewardService
-import com.meokq.api.rank.emoji.ChallengeEmojiRankService
 import com.meokq.api.user.service.AdminService
 import com.meokq.api.user.service.CustomerService
 import com.meokq.api.xp.model.XpType
@@ -51,7 +49,6 @@ class ChallengeService(
     private val customerService: CustomerService,
     private val adminService: AdminService,
     private val emojiRepository: EmojiRepository,
-    private val challengeEmojiRankService: ChallengeEmojiRankService,
     private val rewardService: RewardService,
     private val questRepository: QuestRepository,
     private val xpService: XpService,
@@ -84,7 +81,6 @@ class ChallengeService(
         model.status = status
         val result = saveModel(model)
 
-        challengeEmojiRankService.addToRank(model)
         gainReward(model)
 
         return result
@@ -161,26 +157,9 @@ class ChallengeService(
 
         checkUpdatePermissionForChallenge(authReq, challengeStatus)
 
-        when(challengeStatus){
-            ChallengeStatus.APPROVED -> handleApprovedStatus(model)
-            ChallengeStatus.REPORTED -> handleReportedStatus(model)
-            ChallengeStatus.UNDER_REVIEW, ChallengeStatus.REJECTED -> handleUnsupportedStatus()
-        }
         model.updateStatus(challengeStatus)
 
         return CreateChallengeResp(saveModel(model))
-    }
-
-    private fun handleApprovedStatus(model: Challenge) {
-        challengeEmojiRankService.addToRank(model)
-    }
-
-    private fun handleReportedStatus(model: Challenge) {
-        challengeEmojiRankService.deleteFromRank(model)
-    }
-
-    private fun handleUnsupportedStatus() {
-        throw InvalidRequestException("아직 구현되어 있지 않습니다.")
     }
 
     private fun checkUpdatePermissionForChallenge(
@@ -208,7 +187,6 @@ class ChallengeService(
                     it.quantity!!.toLong()), metadata)
             }
 
-        challengeEmojiRankService.deleteFromRank(challenge)
         emojiRepository.deleteAllByTargetId(challenge.challengeId!!)
         deleteById(challengeId)
     }
@@ -238,7 +216,6 @@ class ChallengeService(
     fun deleteAllByQuestId(questId: String, authReq: AuthReq) {
         val challenges = repository.findAllByQuestId(questId)
         challenges.forEach {
-            challengeEmojiRankService.deleteFromRank(it)
             delete(it.challengeId!!, authReq)
         }
     }
@@ -250,8 +227,8 @@ class ChallengeService(
 
     @Transactional(readOnly = true)
     fun findRandomAll(pageable: Pageable): Page<ReadChallengeResp> {
-        val randomModels = challengeEmojiRankService.fetchShuffleRankToPage(pageable.pageNumber, pageable.pageSize)
-        val responses = randomModels.map(::convertModelToResp)
+        val randomModels = repository.findAllRandomChallenge(pageable)
+        val responses = randomModels.content.map(::convertModelToResp)
         val count = repository.count()
         return PageImpl(responses, pageable, count)
     }
@@ -263,11 +240,6 @@ class ChallengeService(
             challenge.increaseViewCount()
         }
         return ReadChallengeResp(saveModel(challenge))
-    }
-
-    fun updateRank(challengeId: String){
-        val challenge = findModelById(challengeId)
-        challengeEmojiRankService.addToRank(challenge)
     }
 
     private fun convertModelToResp(model: Challenge): ReadChallengeResp {
@@ -305,7 +277,6 @@ class ChallengeService(
             val targetEmojis = groupedEmojis[target.challengeId] ?: emptyList()
             val emojiResps = EmojiResp(targetEmojis)
             target.appendEmojiCnt(emojiResps)
-            challengeEmojiRankService.addToRank(target)
         }
     }
 

--- a/src/main/kotlin/com/meokq/api/emoji/service/EmojiService.kt
+++ b/src/main/kotlin/com/meokq/api/emoji/service/EmojiService.kt
@@ -47,7 +47,6 @@ class EmojiService(
         }
         val result = saveModel(emoji)
 
-        updateEmojiRank(req)
         gainXp(result)
 
         return EmojiDefaultResp(saveModel(emoji))
@@ -59,20 +58,6 @@ class EmojiService(
             action,
             generateMetadataByEmoji(emoji)
         )
-    }
-
-    private fun updateEmojiRank(req: EmojiRegisterReq) {
-        when (TargetType.fromString(req.targetType.uppercase())) {
-            TargetType.CHALLENGE -> {
-                challengeService.updateRank(req.targetId)
-            }
-
-            TargetType.QUEST -> {
-                val quest = questService.findModelById(req.targetId)
-            }
-
-            else -> throw IllegalArgumentException("지원되지 않는 대상 타입입니다.")
-        }
     }
 
     fun delete(authReq: AuthReq, emojiId: String) {

--- a/src/test/kotlin/com/meokq/api/challenge/service/ChallengeServiceTest.kt
+++ b/src/test/kotlin/com/meokq/api/challenge/service/ChallengeServiceTest.kt
@@ -8,6 +8,7 @@ import com.meokq.api.challenge.repository.ChallengeRepository
 import com.meokq.api.challenge.request.ChallengeSaveReq
 import com.meokq.api.core.exception.AccessDeniedException
 import com.meokq.api.emoji.repository.EmojiRepository
+import com.meokq.api.emoji.response.EmojiResp
 import com.meokq.api.file.service.ImageService
 import com.meokq.api.quest.repository.QuestRepository
 import com.meokq.api.quest.request.QuestCreateReq
@@ -22,6 +23,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.data.domain.Pageable
 import org.springframework.test.annotation.Rollback
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.transaction.annotation.Transactional
@@ -251,6 +253,29 @@ internal class ChallengeServiceTest : ChallengeBaseTest(){
         assertEquals(ChallengeStatus.REPORTED, result.status)
     }
 
+    @Test
+    @DisplayName("도전내역 전체를 조회한다.[인증 탭]")
+    fun findRandomAll() {
+        val challenge1 = TestData.saveChallenge(challengeService, testQuest01, testCustomer01)
+        val challenge2 = TestData.saveChallenge(challengeService, testQuest01, testCustomer01)
+        val challenge3 = TestData.saveChallenge(challengeService, testQuest01, testCustomer01)
+        challenge1.appendEmojiCnt(EmojiResp(3, 0))
+        challengeRepository.save(challenge1)
+        challenge2.appendEmojiCnt(EmojiResp(1, 0))
+        challengeRepository.save(challenge2)
+        challenge3.appendEmojiCnt(EmojiResp(0, 0))
+        challengeRepository.save(challenge3)
+
+        val actual = challengeService.findRandomAll(Pageable.unpaged()).content
+        val expected = listOf(challenge2, challenge1, challenge3).map { it.challengeId }
+
+        val actualOrder = actual
+            .filter { actualChallenge ->
+                expected.any { it == actualChallenge.challengeId }
+            }
+            .map { it.challengeId }
+        assertEquals(expected, actualOrder, "Expected order: $expected, but was: $actualOrder")
+    }
 
 
 }


### PR DESCRIPTION
- 랜덤 조회 API DB데이터 조회 변경
    - api/customer/randomChallenge 
- 랜덤 조회 기준 변경
    - 좋아요 5개기준 -> 수정일자 

[Jira - 인증탭 정렬 로직 설계](https://chad0909.atlassian.net/browse/ISPR-223?atlOrigin=eyJpIjoiMTYxNmE0MTc1Yzc2NDAxOWExNzhhZWM2N2U4NTkxMmQiLCJwIjoiaiJ9)